### PR TITLE
#163287884 Adds correct test folders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ install:
   - pip install codecov
   - pip install -r requirements.txt
 script:
-  - py.test --cov=app/tests/v1
+  - py.test --cov=app/api app/tests
 after_success:
   - codecov --token=54348b92-7393-401c-8d60-f8f8449c1674


### PR DESCRIPTION
#### What does this PR do?
Improves test coverage by adding the correct test folder to travis.yml file

#### Description of Task to be completed?
- [x] Add correct test folder to travis.yml
#### How should this be manually tested?
To manually test this:

1. Clone the repository using:
`git clone https://github.com/yunismohamed/Questioner-API.git`
2. Through your terminal, navigate to the cloned repository on your local machine and open it.
3. While in the folder on your terminal, change branches to the `bg-correct-test-coverage-163287884` using `git checkout bg-correct-test-coverage-163287884`.
4. Confirm the contents of `.travis.yml`.

#### What are the relevant pivotal tracker stories?
[#163287884](https://www.pivotaltracker.com/story/show/163287884)